### PR TITLE
Fix RouterOS container import + docs for current RouterOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,25 +45,55 @@ First, set up the required network components on your MikroTik router:
 Set up the required storage:
 
 ```routeros
-# Create RAM disk
+# Create a RAM disk (tmpfs). This is ONLY a staging area for the image .tar.
+# It is wiped on reboot, which is fine: the .tar is only read during import.
 /disk add type=tmpfs tmpfs-max-size=200M
 
-# Create mount points
+# Create the container root dir and the persistent state dir.
+# Both live on the router's internal flash, so they SURVIVE reboots.
 /file/mkdir containers/tailscale
-/file/mkdir /nvme1/container/tailscale/mount
+/file/mkdir containers/tailscale-state
 ```
+
+> **Persistence note:** the hAP ax² has no NVMe/USB by default — its only
+> persistent storage is the internal flash. Earlier versions of this guide
+> referenced `/nvme1/...`; on a stock hAP ax² that is just a folder on flash and
+> is not needed. Keep the container `root-dir` and the state mount on flash (as
+> above) and the node stays authenticated across reboots. Do **not** point
+> `root-dir` or the state mount at the tmpfs disk — it is cleared on reboot.
+
+Define the persistent state mount (the `/container/add` below references it):
+
+```routeros
+# Persist Tailscale's state (node key, etc.) on flash so the node stays
+# authenticated across reboots and container re-creation.
+/container/mounts/add name=tailscale_state src=containers/tailscale-state dst=/var/lib/tailscale
+```
+
+> **Why one mount, not two?** A common broken pattern defines two mounts that
+> both target `/var/lib/tailscale` (e.g. `src=containers/tailscale` **and**
+> `src=containers/tailscale/state`). They conflict, and the first one mounts the
+> container's `root-dir` into itself. Use the single mount above instead.
 
 ### 3. Environment Variables
 
 Configure the required environment variables:
 
 ```routeros
-/container/envs/add name=tailscale key=AUTH_KEY value=your-auth-key-here
-/container/envs/add name=tailscale key=TS_AUTH_KEY value=your-auth-key-here
-/container/envs/add name=tailscale key=ADVERTISE_ROUTES value=192.168.88.0/24
-/container/envs/add name=tailscale key=CONTAINER_GATEWAY value=192.168.98.1
-/container/envs/add name=tailscale key=TAILSCALE_ARGS value="--accept-routes --advertise-exit-node"
+/container/envs/add list=tailscale key=AUTH_KEY value=your-auth-key-here
+/container/envs/add list=tailscale key=ADVERTISE_ROUTES value=192.168.88.0/24
+/container/envs/add list=tailscale key=CONTAINER_GATEWAY value=192.168.98.1
+/container/envs/add list=tailscale key=TAILSCALE_ARGS value="--accept-routes --advertise-exit-node"
 ```
+
+> **`list=` vs `name=`:** current RouterOS (verified on 7.20) expects `list=` for
+> the env-list name; older releases used `name=`. If one returns
+> `expected end of command`, use the other.
+>
+> **Use `AUTH_KEY`, not `TS_AUTH_KEY`:** the entrypoint (`tailscale.sh`) reads
+> `AUTH_KEY`. Setting only `TS_AUTH_KEY` leaves the key empty, and the container
+> falls back to printing an interactive `https://login.tailscale.com/a/...` URL
+> in the logs instead of authenticating. Use a **reusable** key so restarts work.
 
 ### 4. Container Setup
 
@@ -77,19 +107,29 @@ Configure the required environment variables:
 scp tailscale-arm64.tar admin@192.168.88.1:tmp1/
 ```
 
-3. Add the container to RouterOS:
+3. Add the container to RouterOS (enter as a single line — RouterOS does not
+   accept the multi-line form):
 ```routeros
-/container/add
-    file=tmp1/tailscale-arm64.tar
-    interface=veth-tailscale
-    envlist=tailscale
-    root-dir=containers/tailscale
-    mounts=tailscale,tailscale_state
-    start-on-boot=yes
-    hostname=mikrotik-tailscale
-    dns=8.8.4.4,8.8.8.8
-    logging=yes
+/container/add file=tmp1/tailscale-arm64.tar interface=veth-tailscale envlist=tailscale root-dir=containers/tailscale mounts=tailscale_state start-on-boot=yes hostname=mikrotik-tailscale dns=8.8.4.4,8.8.8.8 logging=yes
 ```
+
+The container extracts asynchronously. Watch `/container/print` until it shows
+`stopped` (not `extracting`), then start it and follow the logs:
+```routeros
+/container/start 0
+/log/print where topics~"container"
+```
+
+### 5. Authorize the node in Tailscale
+
+Because this node advertises subnet routes and an exit node, you must approve
+them once in the Tailscale admin console:
+
+1. Open **https://login.tailscale.com/admin/machines**.
+2. Find `mikrotik-tailscale`, and under its route settings **approve the subnet
+   route** (`192.168.88.0/24`) and **enable it as an exit node**.
+3. (Recommended) **Disable key expiry** for the node so it stays connected
+   across reboots without re-authentication.
 
 ## Useful Commands
 
@@ -134,8 +174,8 @@ scp tailscale-arm64.tar admin@192.168.88.1:tmp1/
 # List environment variables
 /container/envs/print
 
-# Add environment variable
-/container/envs/add name=tailscale key=AUTH_KEY value=your-auth-key-here
+# Add environment variable (use list= on current RouterOS; older used name=)
+/container/envs/add list=tailscale key=AUTH_KEY value=your-auth-key-here
 
 # Remove environment variable
 /container/envs/remove [find key=AUTH_KEY]
@@ -165,13 +205,38 @@ scp tailscale-arm64.tar admin@192.168.88.1:tmp1/
    - Solution: Ensure you're using the ARM64 version of the container
 
 2. **Layer Extraction Issues**
-   - Symptom: "error getting layer file" or "failed to load next entry"
-   - Solution: Verify the container image was properly transferred and try rebuilding
+   - Symptom: `*** error getting layer file` / `import error: failed to load next entry`
+   - Cause: modern Docker (BuildKit / containerd image store) writes `docker save`
+     archives as OCI layout with **gzip-compressed** layers, which RouterOS cannot
+     import. (The tar transferred fine — the format is the problem.)
+   - Solution: build with the provided `./build-arm64.sh`, which now repacks the
+     image with uncompressed layers via `pack-for-routeros.py`. To fix a tar you
+     already have: `python3 pack-for-routeros.py old.tar tailscale-arm64.tar`.
 
-3. **Container Not Starting**
-   - Check container logs: `/log/print`
+3. **Container starts but never authenticates (prints a login URL)**
+   - Symptom: logs show `To authenticate, visit: https://login.tailscale.com/a/...`
+   - Cause: the auth key was not passed. The entrypoint reads `AUTH_KEY`; setting
+     only `TS_AUTH_KEY` leaves it empty.
+   - Solution: `/container/envs/add list=tailscale key=AUTH_KEY value=<reusable-key>`,
+     then restart the container.
+
+4. **`health(warnable=router): ... iptables (nf_tables): Could not fetch rule set generation id`**
+   - This warning is expected on RouterOS — the container cannot program the host's
+     netfilter. Routing/NAT is handled by RouterOS itself, so connectivity still
+     works. No action needed.
+
+5. **Container Not Starting**
+   - Check container logs: `/log/print where topics~"container"`
    - Verify environment variables: `/container/envs/print`
    - Ensure mount points exist and are accessible
+
+### Reboot persistence
+
+The container `root-dir` (`containers/tailscale`) and the state mount
+(`containers/tailscale-state`) live on internal flash, and the container has
+`start-on-boot=yes`, so after a reboot it auto-starts and reconnects using the
+persisted node key — no re-upload of the `.tar` and no re-auth required. Only the
+import `.tar` on the tmpfs disk is lost on reboot, which does not affect runtime.
 
 ## Security Considerations
 

--- a/build-arm64.sh
+++ b/build-arm64.sh
@@ -22,8 +22,15 @@ docker build \
   --build-arg TARGETARCH=arm64 \
   -t tailscale-mikrotik-arm64:latest .
 
-echo "Saving container image to tailscale-arm64.tar..."
-docker save -o tailscale-arm64.tar tailscale-mikrotik-arm64:latest
+echo "Saving container image..."
+docker save -o tailscale-arm64.oci.tar tailscale-mikrotik-arm64:latest
+
+# RouterOS cannot import gzip-compressed OCI layers that modern Docker
+# (BuildKit / containerd image store) produces. Repack with uncompressed
+# layers so `/container/add` does not fail with "failed to load next entry".
+echo "Repacking image for RouterOS compatibility..."
+python3 pack-for-routeros.py tailscale-arm64.oci.tar tailscale-arm64.tar
+rm -f tailscale-arm64.oci.tar
 
 # Get the actual image size
 IMAGE_SIZE=$(docker images tailscale-mikrotik-arm64:latest --format "{{.Size}}")

--- a/pack-for-routeros.py
+++ b/pack-for-routeros.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Repack a `docker save` image tar into a form RouterOS containers can import.
+
+Modern Docker (BuildKit / containerd image store) writes `docker save` archives
+in OCI layout with **gzip-compressed** layer blobs. RouterOS 7's container import
+reads `manifest.json` and the image config fine, but cannot read compressed layer
+blobs, so import fails with:
+
+    *** error getting layer file
+    import error: failed to load next entry
+
+This script reads the layer paths listed in `manifest.json` and rewrites any
+gzip-compressed layer as a plain (uncompressed) tar, copying everything else
+through unchanged. Already-uncompressed (legacy) archives pass through untouched.
+
+Usage: pack-for-routeros.py <src.tar> <dst.tar>
+"""
+import gzip
+import io
+import json
+import sys
+import tarfile
+
+GZIP_MAGIC = b"\x1f\x8b"
+
+
+def main(src_path, dst_path):
+    with tarfile.open(src_path, "r") as src:
+        manifest = json.load(src.extractfile("manifest.json"))
+        layer_paths = set()
+        for entry in manifest:
+            layer_paths.update(entry.get("Layers", []))
+
+        decompressed = 0
+        with tarfile.open(dst_path, "w") as out:
+            for m in src.getmembers():
+                if not m.isfile():
+                    out.addfile(m)
+                    continue
+                data = src.extractfile(m).read()
+                if m.name in layer_paths and data[:2] == GZIP_MAGIC:
+                    data = gzip.decompress(data)
+                    decompressed += 1
+                ti = tarfile.TarInfo(m.name)
+                ti.size = len(data)
+                ti.mode = m.mode
+                ti.mtime = m.mtime
+                ti.type = m.type
+                out.addfile(ti, io.BytesIO(data))
+
+    print(f"Repacked {src_path} -> {dst_path} "
+          f"({decompressed} layer(s) decompressed for RouterOS)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(2)
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary

Fixes the issues encountered installing this container on a **hAP ax² running RouterOS 7.20**, and corrects the README commands to match current RouterOS.

## Changes

### 1. Image import fails: `error getting layer file` / `failed to load next entry`
Modern Docker (BuildKit / containerd image store) writes `docker save` archives as **OCI layout with gzip-compressed layers**, which RouterOS's container import cannot read. RouterOS parses `manifest.json` and the image config fine but chokes on the compressed layer blobs.

- Add **`pack-for-routeros.py`**, which rewrites the layer blobs uncompressed (passing legacy/uncompressed archives through untouched).
- Wire it into **`build-arm64.sh`** so the produced `tailscale-arm64.tar` imports cleanly.

### 2. Auth key never applied (container prints an interactive login URL)
The entrypoint `tailscale.sh` reads **`AUTH_KEY`**, but the README also set `TS_AUTH_KEY`, which is unused. With only `TS_AUTH_KEY` set, the key is empty and the container falls back to printing `https://login.tailscale.com/a/...`.
- Drop the `TS_AUTH_KEY` env from the docs; document `AUTH_KEY` and recommend a **reusable** key.

### 3. `/container/envs/add name=...` errors on current RouterOS
Current RouterOS (verified 7.20) expects **`list=`** for the env-list name; `name=` now fails with `expected end of command`. Updated all env commands and added a version note.

### 4. Mounts: undefined + conflicting
The README's `/container/add` referenced `mounts=tailscale,tailscale_state` but **never defined them**. The common two-mount pattern points both mounts at the same `dst=/var/lib/tailscale` (and mounts `root-dir` into itself).
- Document a single **`tailscale_state`** mount on flash (`containers/tailscale-state`).
- Drop the `/nvme1/...` path (hAP ax² has no NVMe; it's just a flash folder).
- Clarify reboot persistence: `root-dir` + state on flash + `start-on-boot=yes` ⇒ reconnects after reboot with no re-auth; only the tmpfs `.tar` (import-only) is lost.

### 5. Docs polish
- `/container/add` as a single pasteable line (RouterOS rejects the multi-line form).
- New step: authorize the subnet route + exit node in the Tailscale admin console.
- Note the harmless `iptables (nf_tables): Could not fetch rule set generation id` health warning.

## Testing
Verified end-to-end on a hAP ax² (RouterOS 7.20.4): repacked image imports successfully, container reaches `Running`, obtains a Tailscale IP, and survives the documented config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
