### PR TITLE
Build current Tailscale (1.98.5) and fix version stamping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,8 @@ ARG TARGETARCH
 # Build tailscale binaries with optimized flags and strip all symbols
 # Use -trimpath to remove file system paths from the resulting binary
 RUN GOARCH=$TARGETARCH CGO_ENABLED=0 go install -trimpath -ldflags="-w -s \
-      -X tailscale.com/version.Long=$VERSION_LONG \
-      -X tailscale.com/version.Short=$VERSION_SHORT \
-      -X tailscale.com/version.GitCommit=$VERSION_GIT_HASH" \
+      -X tailscale.com/version.longStamp=$VERSION_LONG \
+      -X tailscale.com/version.shortStamp=$VERSION_SHORT" \
       -v ./cmd/tailscale ./cmd/tailscaled
 
 # Apply maximum compression with UPX

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #
 ############################################################################
 
-FROM golang:1.23-alpine AS build-env
+FROM golang:1.26-alpine AS build-env
 
 WORKDIR /go/src/tailscale
 

--- a/build-arm64.sh
+++ b/build-arm64.sh
@@ -1,7 +1,7 @@
 #\!/usr/bin/env sh
 # Build script for ARM64 Tailscale MikroTik container
 
-TAILSCALE_VERSION=1.80.1
+TAILSCALE_VERSION=1.98.5
 VERSION=0.1.38
 
 set -eu
@@ -9,16 +9,27 @@ set -eu
 echo "Building optimized Tailscale container for ARM64 (target: <30MB)"
 rm -f tailscale-arm64.tar
 
-if [ \! -d ./tailscale/.git ]
+if [ ! -d ./tailscale/.git ]
 then
     echo "Cloning Tailscale repository (version $TAILSCALE_VERSION)..."
     git -c advice.detachedHead=false clone https://github.com/tailscale/tailscale.git --branch v$TAILSCALE_VERSION
+else
+    echo "Updating Tailscale checkout to v$TAILSCALE_VERSION..."
+    git -C tailscale fetch --tags origin
+    git -C tailscale -c advice.detachedHead=false checkout v$TAILSCALE_VERSION
 fi
 
+# Compute proper version stamps from the Tailscale source so the resulting
+# binary reports a clean version (e.g. "1.98.5") instead of a "-ERR" build.
+echo "Computing version stamps..."
+eval "$(cd tailscale && ./build_dist.sh shellvars)"
+
 # Build the Docker image with standard Docker
-echo "Building optimized container image for ARM64..."
+echo "Building optimized container image for ARM64 (v${VERSION_SHORT})..."
 docker build \
-  --build-arg TAILSCALE_VERSION=$TAILSCALE_VERSION \
+  --build-arg VERSION_LONG="$VERSION_LONG" \
+  --build-arg VERSION_SHORT="$VERSION_SHORT" \
+  --build-arg VERSION_GIT_HASH="$VERSION_GIT_HASH" \
   --build-arg TARGETARCH=arm64 \
   -t tailscale-mikrotik-arm64:latest .
 


### PR DESCRIPTION
## Summary

Builds a current, properly-stamped Tailscale binary. Independent of (and complementary to) the compat/docs PR.

## Changes

- **Bump Tailscale 1.80.1 → 1.98.5.** 1.80.1 is ~18 minor releases behind and carries known security fixes.
- **Fix version stamping (`-ERR-BuildInfo`).** The Dockerfile stamped `tailscale.com/version.Long/Short/GitCommit`, but current Tailscale renamed these to `version.longStamp`/`shortStamp`. With the old names the `-X` flags were silently ignored, so binaries reported e.g. `1.80.1-ERR-BuildInfo`. `build-arm64.sh` also never passed the version build-args at all. Now it computes them via Tailscale's own `build_dist.sh shellvars` and the Dockerfile uses the current symbol names.
- **Bump builder `golang:1.23 → golang:1.26`** (Tailscale 1.98.5 requires Go 1.26).
- **Update an existing `./tailscale` checkout** to the requested tag instead of only cloning when absent.

## Testing

Built and deployed to a hAP ax² (RouterOS 7.20.4). `tailscaled` now logs a clean version:
`Program starting: v1.98.5-t295179bf2, Go 1.26.4` (previously `…-ERR-BuildInfo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
